### PR TITLE
FIxing transparent window title bug

### DIFF
--- a/aurorae/Win10OS-dark/Win10OS-darkrc
+++ b/aurorae/Win10OS-dark/Win10OS-darkrc
@@ -1,6 +1,6 @@
 [General]
-ActiveTextColor=255,255,255,255
-InactiveTextColor=255,255,255,128
+ActiveTextColor=255,255,255
+InactiveTextColor=112,111,110
 TitleAlignment=Left
 TitleVerticalAlignment=Center
 Animation=0


### PR DESCRIPTION
For dark theme, guided by how other fonts get gray